### PR TITLE
Master release v2.2.2 : update version

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pretzel-frontend",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Frontend code for Pretzel",
   "license": "MIT",
   "author": "",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pretzel",
   "private": true,
-  "version": "2.2.1",
+  "version": "2.2.2",
   "dependencies": {
   },
   "repository" :


### PR DESCRIPTION
No functional change - just updating the version string.
The tag v2.2.2 on the commit which made this change was pushed before the PR #195 was created, but it is necessary to push HEAD (develop) also.
