### PR TITLE
Master Release v2.17.6

### DIFF
--- a/doc/notes/connected_databases.md
+++ b/doc/notes/connected_databases.md
@@ -1,0 +1,154 @@
+
+### Connecting additional genomics and bioinformatics databases to Pretzel
+
+Pretzel can integrate information from additional databases such as Blast and VCF into the display.
+These databases may have varying names for datasets and chromosomes.
+To align the chromosome names, the .name field of the Blocks of the BlastDB or VCF dataset are set to the chromosome name used by external database.  Pretzel uses the Block .scope field to determine the chromosome axis on which a dataset is displayed, i.e. Block .scope identifies the chromosome in Pretzel.
+
+Here are the steps for checking that the blast db chr name is configured in mongo db :
+
+```
+datasetId=Triticum_aestivum_IWGSC_RefSeq_v1.0
+cd /mnt/data_blast/blast/datasetId
+cat $datasetId.dbName
+161010_Chinese_Spring_v1.0_pseudomolecules.fasta
+
+ls -gG $datasetId.dir/$(cat $datasetId.dbName).fai
+ 723 Jan 24  2023 Triticum_aestivum_IWGSC_RefSeq_v1.0.dir/161010_Chinese_Spring_v1.0_pseudomolecules.fasta.fai
+
+cat $datasetId.dir/$(cat $datasetId.dbName).fai
+chr1A	594102056	7	60	61
+chr1B	689851870	604003771	60	61
+chr1D	495453186	1305353180	60	61
+chr2A	780798557	1809063927	60	61
+chr2B	801256715	2602875801	60	61
+chr2D	651852609	3417486802	60	61
+chr3A	750843639	4080203629	60	61
+chr3B	830829764	4843561336	60	61
+chr3D	615552423	5688238270	60	61
+chr4A	744588157	6314049908	60	61
+chr4B	673617499	7071047875	60	61
+chr4D	509857067	7755892340	60	61
+chr5A	709773743	8274247032	60	61
+chr5B	713149757	8995850345	60	61
+chr5D	566080677	9720885939	60	61
+chr6A	618079260	10296401301	60	61
+chr6B	720988478	10924781889	60	61
+chr6D	473592718	11657786849	60	61
+chr7A	736706236	12139272786	60	61
+chr7B	750620385	12888257467	60	61
+chr7D	638686055	13651388199	60	61
+chrUn	480980714	14300719029	60	61
+```
+
+```
+# Determine mongo container id
+# On main this is already done in ~/.bash_custom
+function dockerContainer() {
+  image=$1;
+  docker ps --format "{{.ID}}\t{{.Image}}" | sed -n "s/	$image.*//p"
+}
+DIM=$(dockerContainer mongo)
+
+# or determine mongo container id using docker ps :
+...
+b371fe05350e   mongo:4.2                                       "docker-entrypoint.s…"   12 months ago   Up 2 months   0.0.0.0:27017->27017/tcp, :::27017->27017/tcp   exciting_agnesi
+DIM=b371
+```
+
+`DB_NAME=pretzel`
+```
+# except on main :
+echo $DB_NAME
+admin
+```
+
+```
+docker exec -it $DIM mongo --quiet $DB_NAME
+
+# Similarly for VCF : "tags" : [ "view", "VCF" ], 
+db.Dataset.aggregate({$match : {tags : { $exists: true}}},
+ {$match : {$expr : {$in : ["BlastDb", "$tags"]}}},
+ {$project : {_id : 1}} )
+
+{ "_id" : "Triticum_aestivum_IWGSC_RefSeq_v1.0" }
+{ "_id" : "Jagger" }
+{ "_id" : "ArinaLrFor" }
+{ "_id" : "Julius" }
+{ "_id" : "Mace" }
+{ "_id" : "Hordeum_vulgare_RGT_Planet_v1" }
+{ "_id" : "Hordeum_vulgare_HOR9043_v1.1" }
+{ "_id" : "Triticum_aestivum_IWGSC_RefSeq_v2.0" }
+
+
+DBQuery.shellBatchSize=100
+db.Block.aggregate({$match : {datasetId : "Triticum_aestivum_IWGSC_RefSeq_v1.0"}}, {"$project" : {_id : 0, name : 1, scope: 1}})
+
+{ "scope" : "1A", "name" : "1A" }
+{ "scope" : "1B", "name" : "1B" }
+{ "scope" : "1D", "name" : "1D" }
+{ "scope" : "2A", "name" : "2A" }
+{ "scope" : "2B", "name" : "2B" }
+{ "scope" : "2D", "name" : "2D" }
+{ "scope" : "3A", "name" : "3A" }
+{ "scope" : "3B", "name" : "3B" }
+{ "scope" : "3D", "name" : "3D" }
+{ "scope" : "4A", "name" : "4A" }
+{ "scope" : "4B", "name" : "chr4B" }
+{ "scope" : "4D", "name" : "chr4D" }
+{ "scope" : "5A", "name" : "5A" }
+{ "scope" : "5B", "name" : "5B" }
+{ "scope" : "5D", "name" : "5D" }
+{ "scope" : "6A", "name" : "6A" }
+{ "scope" : "6B", "name" : "6B" }
+{ "scope" : "6D", "name" : "6D" }
+{ "scope" : "7A", "name" : "7A" }
+{ "scope" : "7B", "name" : "7B" }
+{ "scope" : "7D", "name" : "7D" }
+{ "scope" : "Un", "name" : "Un" }
+```
+
+
+4B and 4D are configured to match the blast db.
+To configure the remainder :
+```
+datasetId=Triticum_aestivum_IWGSC_RefSeq_v1.0
+for chrName in $(echo {1,2,3,4,5,6,7}{A,B,D}) ; do echo "db.Block.updateOne({datasetId : '$datasetId', scope : '$chrName'}, {\$set : {name : 'chr$chrName'}});"; done  | docker exec -i $DIM mongo --quiet $DB_NAME
+```
+this does e.g. :
+```
+db.Block.updateOne({datasetId : 'Triticum_aestivum_IWGSC_RefSeq_v1.0', scope : '1A'}, { : {name : 'chr1A'}})
+...
+```
+
+output :
+```
+{ "acknowledged" : true, "matchedCount" : 1, "modifiedCount" : 1 }
+{ "acknowledged" : true, "matchedCount" : 1, "modifiedCount" : 1 }
+{ "acknowledged" : true, "matchedCount" : 1, "modifiedCount" : 1 }
+{ "acknowledged" : true, "matchedCount" : 1, "modifiedCount" : 1 }
+{ "acknowledged" : true, "matchedCount" : 1, "modifiedCount" : 1 }
+{ "acknowledged" : true, "matchedCount" : 1, "modifiedCount" : 1 }
+{ "acknowledged" : true, "matchedCount" : 1, "modifiedCount" : 1 }
+{ "acknowledged" : true, "matchedCount" : 1, "modifiedCount" : 1 }
+{ "acknowledged" : true, "matchedCount" : 1, "modifiedCount" : 1 }
+{ "acknowledged" : true, "matchedCount" : 1, "modifiedCount" : 1 }
+{ "acknowledged" : true, "matchedCount" : 1, "modifiedCount" : 0 }
+{ "acknowledged" : true, "matchedCount" : 1, "modifiedCount" : 0 }
+{ "acknowledged" : true, "matchedCount" : 1, "modifiedCount" : 1 }
+{ "acknowledged" : true, "matchedCount" : 1, "modifiedCount" : 1 }
+{ "acknowledged" : true, "matchedCount" : 1, "modifiedCount" : 1 }
+{ "acknowledged" : true, "matchedCount" : 1, "modifiedCount" : 1 }
+{ "acknowledged" : true, "matchedCount" : 1, "modifiedCount" : 1 }
+{ "acknowledged" : true, "matchedCount" : 1, "modifiedCount" : 1 }
+{ "acknowledged" : true, "matchedCount" : 1, "modifiedCount" : 1 }
+{ "acknowledged" : true, "matchedCount" : 1, "modifiedCount" : 1 }
+{ "acknowledged" : true, "matchedCount" : 1, "modifiedCount" : 1 }
+```
+
+checking :
+```
+[@main. ~]$  echo "DBQuery.shellBatchSize=100; db.Block.find({datasetId : '$datasetId'})" | docker exec -i $DIM mongo --quiet $DB_NAME
+{ "_id" : ObjectId("5b69dd44b1b8780b8739f694"), "scope" : "1A", "name" : "chr1A", "range" : [ 1, 594102056 ], "datasetId" : "Triticum_aestivum_IWGSC_RefSeq_v1.0", "featureType" : "linear" }
+...
+```

--- a/frontend/app/components/draw/graph-annotations.js
+++ b/frontend/app/components/draw/graph-annotations.js
@@ -152,7 +152,9 @@ export default class DrawGraphAnnotationsComponent extends Component {
       pM = pE.merge(pS);
       pM
         .transition().duration(100)
-        .attr('d', axis1d => this.annotationPath(axis1d, tableX, tableRowInterval));
+        .attr('d', axis1d =>
+          axis1d && ! axis1d.isDestroying &&
+            this.annotationPath(axis1d, tableX, tableRowInterval));
       pS.exit().remove();
       if (trace) {
         dLog(fname, axes, viewportWidth, tableX, stackLocation, pS.nodes(), pE.nodes(), pM.node(), pM.nodes());

--- a/frontend/app/components/draw/graph-annotations.js
+++ b/frontend/app/components/draw/graph-annotations.js
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import { computed } from '@ember/object';
 import { alias, reads } from '@ember/object/computed';
 import { later, /*once, bind,*/ debounce } from '@ember/runloop';
-import { task, didCancel } from 'ember-concurrency';
+import { /*task,*/ didCancel } from 'ember-concurrency';
 
 import { keepLatestTask } from 'ember-concurrency-decorators';
 
@@ -57,6 +57,15 @@ export default class DrawGraphAnnotationsComponent extends Component {
 
   //----------------------------------------------------------------------------
 
+  willDestroy() {
+    dLog('willDestroy');
+    // .renderOnce() will get cancelled so use .render().
+    this.render();
+    window.PretzelFrontend.graphAnnotations = null;
+  }
+
+  //----------------------------------------------------------------------------
+
   @computed()
   get renderOnceFn () {
     return () => ! this.isDestroying && this.renderOnce();
@@ -75,6 +84,7 @@ export default class DrawGraphAnnotationsComponent extends Component {
             dLog(fnName, 'taskInstance.catch', error);
             throw error;
           } else {
+            dLog(fnName, 'taskInstance.catch', 'TaskCancelation', error);
           }
         });
     }
@@ -157,7 +167,9 @@ export default class DrawGraphAnnotationsComponent extends Component {
             this.annotationPath(axis1d, tableX, tableRowInterval));
       pS.exit().remove();
       if (trace) {
-        dLog(fname, axes, viewportWidth, tableX, stackLocation, pS.nodes(), pE.nodes(), pM.node(), pM.nodes());
+        dLog(
+          fname, model.userSettings.genotype.showTablePositionAlignment, tableIsVisible,
+          axes, viewportWidth, tableX, stackLocation, pS.nodes(), pE.nodes(), pM.node(), pM.nodes());
       }
     }
   }

--- a/frontend/app/components/matrix-view.js
+++ b/frontend/app/components/matrix-view.js
@@ -696,16 +696,18 @@ export default Component.extend({
    */
   getLimitFeatures() {
     let features = [];
-    /** displayDataRows is undefined if empty. In that case (gtMergeRows) may be
-     * defined, with .length 0, so the result is undefined, as required.
+    /** displayDataRows is [] if empty (in gtMergeRows case);
+     * in that case the result is [], as required.
      */
     if (this.displayDataRows) {
       const d = this.displayDataRows;
-      features[0] = d[sparseArrayFirstIndex(d)];
-      features[1] = d.at(-1);
+      if (d.length) {
+        features[0] = d[sparseArrayFirstIndex(d)];
+        features[1] = d.at(-1);
+      }
     } else if (this.displayData) {
       const f = this.displayData.find(d => d.features)?.features;
-      if (f) {
+      if (f?.length) {
         features[0] = f[0];
         features[1] = f.at(-1);
       }

--- a/frontend/app/components/matrix-view.js
+++ b/frontend/app/components/matrix-view.js
@@ -595,6 +595,9 @@ export default Component.extend({
     }
     this.addComponentClass();
   },
+  /** Update the class list of the component element. Classes :
+   * . gtMergeRows
+   */
   addComponentClass() {
     /** gtMergeRows : datasetId is not displayed, so width is not set  */
     let ot = d3.select('#observational-table');
@@ -611,7 +614,7 @@ export default Component.extend({
     fnName = 'topLeftDialogUpdate',
     /** related : cornerClones */
     topLeftDialog = $('#observational-table .ht_clone_top_left_corner .colHeader.cornerHeader')[0];
-    dLog(fnName, topLeftDialog);
+    // dLog(fnName, topLeftDialog);
     Ember_set(this, 'tableApi.topLeftDialog', topLeftDialog);
     this.addComponentClass();
   },

--- a/frontend/app/components/panel/manage-genotype.js
+++ b/frontend/app/components/panel/manage-genotype.js
@@ -1529,7 +1529,7 @@ export default class PanelManageGenotypeComponent extends Component {
       block = abBlock.block,
       dataset = block.get('datasetId.content'),
       axis1d = block.get('axis1d'),
-      colour = axis1d.blockColourValue(block);
+      colour = axis1d ? axis1d.blockColourValue(block) : 'black';
       datasetsSet.add(dataset);
       map.set(dataset, colour);
       return map;
@@ -1572,7 +1572,8 @@ export default class PanelManageGenotypeComponent extends Component {
   get brushedOrViewedVCFAxes() {
     const
     vcfBlocks = this.brushedVCFBlocks.map((abb) => abb.block),
-    axes = vcfBlocks.mapBy('axis1d').uniq();
+    /** filter out undefined block.axis1d which may occur during block view / unview. */
+    axes = vcfBlocks.mapBy('axis1d').filter(a1 => a1).uniq();
     return axes;
   }
   @computed('brushedOrViewedVCFAxes', 'brushedOrViewedVCFAxes.0.zoomCounter')
@@ -3662,7 +3663,7 @@ export default class PanelManageGenotypeComponent extends Component {
       const
       values = features.mapBy('value').flat(),
       valueExtent = d3.extent(values),
-      axes = features.mapBy('blockId.axis1d'),
+      axes = features.mapBy('blockId.axis1d').filter(a1 => a1),
       /** Features could be of multiple axes; can pass all features and collate
        * extents for each axis separately.  */
       axis1d = axes[0];

--- a/frontend/app/components/panel/manage-genotype.js
+++ b/frontend/app/components/panel/manage-genotype.js
@@ -2709,6 +2709,9 @@ export default class PanelManageGenotypeComponent extends Component {
    */
   showSamplesWithinBrush() {
     const fnName = 'showSamplesWithinBrush';
+    if (! this.gtBlocks.length) {
+      this.emptyTable();
+    } else
     if (! this.axisBrush /* || ! this.lookupBlock*/) {
       // perhaps clear table
     } else {
@@ -2898,6 +2901,20 @@ export default class PanelManageGenotypeComponent extends Component {
         }
       }
     }
+  }
+  /** Set the data content of the table to empty. */
+  emptyTable() {
+    const gtMergeRows = this.urlOptions.gtMergeRows;
+    setProperties(this, {
+      displayData : gtMergeRows ? null : [],
+      displayDataRows : gtMergeRows ? [] : null,
+      gtDatasetColumns : [],
+      datasetColumns : [],
+      extraDatasetColumns : [],
+      currentFeaturesValuesFields : [],
+      columnNames : [],
+    });
+
   }
   /** A filterFn for featureSampleNames() : omit Ref & Alt.
    * Used in showSamplesWithinBrush() to omit Ref & Alt

--- a/frontend/app/components/panel/upload/blast-results-view.js
+++ b/frontend/app/components/panel/upload/blast-results-view.js
@@ -360,9 +360,7 @@ export default Component.extend({
 
     let
     /** it is possible that the parent reference does not have blocks with name matching the results (blockNames) */
-    blocks = this.get('resultParentBlocks'),
-    /** split resultParentBlocks() into parentBlocks and resultParentBlocksByName(); array result is not required. */
-    blocksByName = blocks.reduce((result, block) => {result[block.get('name')] = block; return result; }, {});
+    blocksByName = this.get('resultParentBlocksByName'),
     blocks = blocksByName;
 
     /** toView[<Boolean>] is an array of blockNames to view / unview (depending on <Boolean> flag). */
@@ -386,10 +384,9 @@ export default Component.extend({
       (viewFlag) => toView[viewFlag] && this.get('viewDataset')(parentName, viewFlag, toView[viewFlag]));
   },
 
-  resultParentBlocks : computed('search.parent', 'blockNames.[]', function () {
-    const fnName = 'resultParentBlocks';
+  parentBlocks : computed('search.parent', function () {
+    const fnName = 'parentBlocks';
     let parentName = this.get('search.parent');
-    let blockNames = this.get('blockNames');
     let
     /** lookup on the server selected in dataset explorer, not primary. */
     server = this.get('apiServers').get('serverSelected'),
@@ -399,14 +396,23 @@ export default Component.extend({
      */
     if (! dataset) {
       dataset = server?.datasetsBlocks.findBy('name', parentName);
-      dLog('resultParentBlocks serverSelected dataset', dataset, parentName);
+      dLog(fnName, 'serverSelected dataset', dataset, parentName);
     }
     let
-    blocks = dataset && dataset.get('blocks').toArray()
-      .filter((b) => (blockNames.indexOf(b.get('name')) !== -1) );
+    blocks = dataset && dataset.get('blocks').toArray();
+    return blocks;
+  }),
+  resultParentBlocksByName : computed('parentBlocks', 'blockNames.[]', function () {
+    const fnName = 'resultParentBlocks';
+
+    let blockNames = this.get('blockNames');
+    const
+    blocks = this.parentBlocks
+      .reduce((result, block) => {result[block.get('name')] = block; return result; }, {});
 
     if (! blocks.length && blockNames.length) {
-      dLog('resultParentBlocks', parentName, dataset, blockNames, blocks);
+      const parentName = this.get('search.parent');
+      dLog(fnName, parentName, blockNames, blocks);
     }
     return blocks;
   }),
@@ -465,9 +471,13 @@ export default Component.extend({
         this.get('search.parent'),
         namespace
       );
+      const
+      blocksByName = this.get('resultParentBlocksByName'),
+      scopesForNames = this.get('blockNames').map(name => blocksByName[name]?.scope || name);
       let blocks = transient.blocksForSearch(
         datasetName,
         this.get('blockNames'),
+        scopesForNames,
         namespace
       );
       /** change features[].blockId to match blocks[], which has dataset.id prefixed to make them distinct.  */

--- a/frontend/app/services/data/transient.js
+++ b/frontend/app/services/data/transient.js
@@ -91,17 +91,21 @@ export default Service.extend({
     return record;
   },
 
-  pushBlockArgs(datasetId, name, namespace) {
+  pushBlockArgs(datasetId, name, scope, namespace) {
     let
     /** may need to pass search ID also; depends on whether distinct blocks should be used for each search result. */
     /** prefix _id with datasetId to make it unique enough.  May use UUID. */
-    data = {_id : datasetId + '-' + name, scope : name, name, namespace, datasetId},
+    data = {_id : datasetId + '-' + name, scope, name, namespace, datasetId},
     store = this.get('store'),
     record = this.pushData(store, 'block', data);
     return record;
   },
-  blocksForSearch(datasetId, blockNames, namespace) {
-    let blocks = blockNames.map((name) => this.pushBlockArgs(datasetId, name, namespace));
+  /** Push into the (default) store blocks for the given datasetId and {name,scope,namespace}
+   * @param blockNames, scopesForNames are parallel
+   */
+  blocksForSearch(datasetId, blockNames, scopesForNames, namespace) {
+    let blocks = blockNames.map((name, i) =>
+      this.pushBlockArgs(datasetId, name, scopesForNames[i], namespace));
     return blocks;
   },
 

--- a/frontend/app/styles/app.scss
+++ b/frontend/app/styles/app.scss
@@ -183,7 +183,9 @@ div.app-logo {
 .resizer
 {
   font-weight: 900;
-  font-size: larger;
+  // changed from larger for .gtResizeHeader, probably OK for other uses.
+  font-size: x-large;
+  cursor: ns-resize;
   float: right;
   /* align the icon above the border it moves */
   margin-right: -6px  !important;
@@ -209,14 +211,14 @@ div.app-logo {
   content: "\21F9";
   right: -20px;
   position: relative;
-  left: 4px;
+  left: 19px;
   /* require a minimum of 121 to be above the HandsOnTable elements near this element. */
   z-index: 181;
 }
 .resizer.vertical:not(.inFO):not(.no-resizer-icon)::after
 {
   right : inherit;
-  bottom: calc(0px - var(--matrixViewColumnHeaderHeight));
+  bottom: calc(50px - var(--matrixViewColumnHeaderHeight));
   /** ↧ Downwards Arrow from Bar.   https://symbl.cc/en/21A7/ */
   content: "\21A7";
 }
@@ -231,7 +233,7 @@ div.app-logo {
  */
 .resizer:hover
 {
-  opacity : 0.7;
+  // opacity : 0.7;	// seems to cause jitter
   color: hsl(208, 95%, 52%);	// #337ab7 with increased saturation and luminosity
 }
 /* The resizer icon is wrapped in div.menuHead : width: 100%, so that it remains

--- a/frontend/app/templates/components/draw/stacks-view.hbs
+++ b/frontend/app/templates/components/draw/stacks-view.hbs
@@ -12,9 +12,11 @@
   stacksView=this
   featuresInBlocks=featuresInBlocks
 }}
+{{#if @model.userSettings.genotype.showTablePositionAlignment}}
 {{draw/graph-annotations
   model=model
   stacksView=this
   rightAxes=this.rightStack.axes
 }}
+{{/if}}
 {{yield}}

--- a/frontend/app/utils/data/vcf-feature.js
+++ b/frontend/app/utils/data/vcf-feature.js
@@ -365,7 +365,7 @@ function addFeaturesJson(block, requestFormat, replaceResults, selectedService, 
           break;
 
         case 'POS' :
-          value = +value;
+          value = parseNumber(value);
           f['value_0'] = value;
           value = [ value ];
           break;
@@ -380,19 +380,23 @@ function addFeaturesJson(block, requestFormat, replaceResults, selectedService, 
           const infoEntries = value.split(';').map(kv => kv.split('='));
           value = Object.fromEntries(infoEntries);
 
-          // Convert numeric values from string to number.
-          // equivalent : parseBooleanFields(f.values, ['MAF', 'tSNP']);
           if (value.MAF) {
-            value.MAF = +value.MAF;
+            value.MAF = parseNumber(value.MAF);
           }
           if (value.tSNP) {
-            value.tSNP = +value.tSNP;  // maybe accept any string.
+            if ((value.tSNP === '.') || (value.tSNP === '')) {
+              delete value.tSNP;
+            } else {
+              value.tSNP = parseNumber(value.tSNP);
+            }
           }
+          parseNumberFields(value);
 
           break;
 
         default :
           fieldNameF = 'values.' + fieldName;
+          value = parseNumber(value);
         }
         if (! fieldNameF) {
           dLog(fnName, fieldName, value, i);
@@ -704,6 +708,31 @@ function variantNameSplit(variantName, traceUnmatched) {
 }
 
 // -----------------------------------------------------------------------------
+
+/** Convert numeric value from string to number.
+ * If given value is not numeric, return the param.
+ * Related : parseNumberFields(), parseBooleanFields();
+ * @param text
+ * @return text unchanged if it is not numeric
+ */
+function parseNumber(text) {
+  const
+  number = Number(text),
+  result = isNaN(number) ? text : number;
+  return result;
+}
+/** Convert numeric string values in object to number.
+ */
+function parseNumberFields(obj) {
+  /** Convert numeric strings to numbers. */
+  Object.entries(obj).forEach(([k, v]) => {
+    const number = Number(v);
+    if (! isNaN(number)) {
+      obj[k] = number;
+    }
+  });
+}
+
 
 /** if string.match(regexp), return match[valueIndex], otherwise undefined. 
  */
@@ -1810,6 +1839,8 @@ export {
   resultIsGerminate,
   addFeaturesGerminate,
   variantNameSplit,
+  parseNumber,
+  parseNumberFields,
   featureBlockColourValue,
   normalizeMaf,
   sampleIsFilteredOut,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pretzel-frontend",
-  "version": "2.17.5",
+  "version": "2.17.6",
   "description": "Frontend code for Pretzel",
   "repository": "",
   "license": "MIT",

--- a/lb4app/lb3app/server/server.js
+++ b/lb4app/lb3app/server/server.js
@@ -52,6 +52,7 @@ envNames =
     'DEBUG',
     'DOTENV_CONFIG_DEBUG',
     'DOTENV_CONFIG_PATH',
+    'DOTENV_CONFIG_OVERRIDE',
   ];
 const
 processFieldNames =

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pretzel",
   "private": true,
-  "version": "2.17.5",
+  "version": "2.17.6",
   "dependencies": {
   },
   "repository" :


### PR DESCRIPTION
Enable blast chromosome name to be configured to be different to Pretzel reference chromosome name :
- Load blast search results with block .scope matching reference ade64e58

Documentation of that configuration process :
- add note on configuring chromosome names of Blast and VCF databases 1e356e04
  (Note it is easier to configure this before loading the reference dataset, in the reference spread-sheet or json)

Minor genotype table improvements :
- Clear genotype table when axis is closed or vcf block is un-viewed a6661432
- split INFO column into multiple columns in feature table 9c2c7c14
- handle empty genotype table cf6c0985
- make column header height resizer easier to grab fa727f42 
- only create graph-annotations component while showTablePositionAlignment is true f3e9652d
