### PR TITLE
Genotype Table : Filtered Samples update for multiple chromosomes

### DIFF
--- a/frontend/app/components/panel/genotype-samples.hbs
+++ b/frontend/app/components/panel/genotype-samples.hbs
@@ -99,7 +99,8 @@
     <Textarea
       class="selectedSamplesInput"
       @value={{@the.selectedSamplesText}}
-      @input={{action @the.sampleNameListInputKey value="target.value" }}
+      {{ on 'input' (action @the.sampleNameListInputKey value="target.value" ) }}
+      {{!-- now that input is re-connected, these 3 are probably not required --}}
       @enter={{@the.sampleNameListInput}}
       @insert-newline={{@the.sampleNameListInput}}
       @escape-press={{@the.sampleNameListInput}}

--- a/frontend/app/components/panel/genotype-search.hbs
+++ b/frontend/app/components/panel/genotype-search.hbs
@@ -48,7 +48,7 @@
     <Textarea
       class="selectedFeaturesInput"
       @value={{this.selectedFeaturesText}}
-      @input={{action this.featureNameListInputKey value="target.value" }}
+      oninput={{action this.featureNameListInputKey value="target.value" }}
       @enter={{this.featureNameListInput}}
       @insert-newline={{this.featureNameListInput}}
       @escape-press={{this.featureNameListInput}}

--- a/frontend/app/components/panel/manage-genotype.js
+++ b/frontend/app/components/panel/manage-genotype.js
@@ -1741,7 +1741,7 @@ export default class PanelManageGenotypeComponent extends Component {
       .trimEnd(/\n/)
       .split(/\n *\t*/g)
       .filter((name) => !!name);
-    dLog(fnName, value, selected);
+    dLog(fnName, value.length, value.slice(-50), selected.length);
     return selected;
   }
   /** parse the contents of the textarea -> selectedSamples
@@ -1756,15 +1756,20 @@ export default class PanelManageGenotypeComponent extends Component {
    * was last called.
    */
   selectedSamplesTextLines = null;
-  /** Called by @input - any user edit key.
+  /** Called by {{ on 'input' }} (equivalent to oninput=) - any user edit key.
    * Set this.selectedSamplesText to value.
    * If edit is substantial, e.g. changes # lines, then sampleNameListInput().
    */
   @action
   sampleNameListInputKey(value) {
+    const fnName = 'sampleNameListInputKey';
     this.selectedSamplesText = value;
     const
+    /** When Backspace or Delete removes the content of a line but not the
+     * newline, it would be good to update, i.e. exclude blank lines from the
+     * count. */
     lines = stringCountString(value, '\n');
+    dLog(fnName, value.length, lines, this.selectedSamplesTextLines);
     if (lines != this.selectedSamplesTextLines) {
       this.selectedSamplesTextLines = lines;
       this.sampleNameListInput(value);

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pretzel-frontend",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "description": "Frontend code for Pretzel",
   "repository": "",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pretzel",
   "private": true,
-  "version": "3.7.1",
+  "version": "3.7.2",
   "dependencies": {
   },
   "repository" :


### PR DESCRIPTION
#### Genotype Table : Filtered Samples update for multiple chromosomes

- #505
 d2571a62 update after user edits to Selected Samples, without requiring Enter
 2c605444 Enable featureNameListInputKey in genotype-search
- #495
 bc79a03d ensure that genotypeSamplesFilteredByHaplotypes is updated and filtered samples are requested for all brushed blocks with selected SNPs
