### PR TITLE
#536 Disable Filter by Haplotype checkbox when no SNPs selected

### DIFF
--- a/frontend/app/components/panel/genotype-samples.hbs
+++ b/frontend/app/components/panel/genotype-samples.hbs
@@ -20,18 +20,28 @@
   {{/if}}
 
   <div>
-    {{#if @the.featureFiltersCountOfDatasetInBrushedDomain.length}}
+   
     <span>
     <input type="checkbox"
       checked={{@userSettings.filterSamplesByHaplotype}}
+      disabled={{not @the.featureFiltersCountOfDatasetInBrushedDomain.length}}
       oninput={{pipe (action (mut @userSettings.filterSamplesByHaplotype) value="target.checked")
         @the.ensureSamples }}  >
-    <label>Filter by defined Haplotype</label>
-    {{#ember-tooltip side="bottom-start" delay=1500}}
-      Show samples selected by SNP filters
-    {{/ember-tooltip}}
+    <label class={{if (not @the.featureFiltersCountOfDatasetInBrushedDomain.length) "disabled"}}>
+      Filter by defined Haplotype
+    </label>
+    {{#if @the.featureFiltersCountOfDatasetInBrushedDomain.length}}
+      {{#ember-tooltip side="bottom-start" delay=500}}
+        Show samples selected by SNP filters
+      {{/ember-tooltip}}
+      {{else}}
+      <a target="_blank" href="https://docs.plantinformatics.io/Basic-Functions/Genotype-tab/#selecting-a-haplotype-and-ordering-the-genotype-matrix"><i class="glyphicon glyphicon-question-sign" o></i></a>
+      {{#ember-tooltip side="bottom-start" delay=500}}
+        No SNPs selected, please select some SNPs first.
+      {{/ember-tooltip}}
+    {{/if}}
     </span>
-
+ {{#if @the.featureFiltersCountOfDatasetInBrushedDomain.length}}
       <span class="sample-count"> (
         {{@the.featureFiltersCountOfDatasetInBrushedDomain.length}}
         {{#unless (eq @the.featureFiltersCountOfDatasetInBrushedDomain.length @the.featureFiltersCount) }} 

--- a/frontend/app/styles/app.scss
+++ b/frontend/app/styles/app.scss
@@ -858,6 +858,7 @@ svg.applyChange path.syntenyEdge {
 .disabled {
   pointer-events: none;
   cursor: default;
+  color: #999;
 }
 
 /*----------------------------------------------------------------------------*/


### PR DESCRIPTION
- added a grey colour for the disabled class
- added a condition such that if no SNPs are selected the checkbox will be in a disabled state
- added link to documentation when in the disabled state
- added a alternative tool tip to show when in a disabled state