### PR TITLE
Release v3.9.2 : ObjectIDs in API responses.  scroll bar under tables. 

### DIFF
--- a/frontend/app/components/matrix-view.js
+++ b/frontend/app/components/matrix-view.js
@@ -101,10 +101,12 @@ const featureValuesWidths = {
 
 /** Initially '100%', but that puts horizontal scrollbar below the browser window.
  * Recalculated to a px value by tableHeightFromParent().
- * vh doesn't seem to work here. */
-let tableHeight = '100%';
+ * vh doesn't seem to work here.
+ * Update : 99.9% works, so calculateTableHeight is set to false.
+ */
+let tableHeight = '99.9%';
 /** Enable use of tableHeightFromParent().  */
-const calculateTableHeight = true;
+const calculateTableHeight = false;
 /** The tabs within showSampleFilters
  * (tab-view-SampleFilter-{haplotype,variantInterval,feature} ) which sets
  * .sampleFilterTypeName can be used to limit the available user actions :
@@ -268,7 +270,8 @@ export default Component.extend({
 
   //----------------------------------------------------------------------------
 
-  classNames: ['matrix-view'],
+  /** parent is mapview.hbs : #right-panel-content */
+  classNames: ['matrix-view flex-grow-1'],
 
   //----------------------------------------------------------------------------
 
@@ -495,6 +498,11 @@ export default Component.extend({
 
   /** Calculate height of table in px to enable horizontal scrollbar below table
    * to be visible.
+   *
+   * Using tableHeight 99.9% instead of 100% works, so calculateTableHeight has
+   * been set false, i.e. this function is not currently used; it would probably
+   * need to be updated as the addition of Genolink buttons in the top panel
+   * increases its height, when enabled by .genolinkSearchURL.
    */
   tableHeightFromParent(tableDiv) {
     const
@@ -695,7 +703,7 @@ export default Component.extend({
     /** related : cornerClones */
     topLeftDialog = $('#observational-table .ht_clone_top_left_corner .colHeader.cornerHeader')[0];
     // dLog(fnName, topLeftDialog);
-    later(() => Ember_set(this, 'tableApi.topLeftDialog', topLeftDialog));
+    later(() => ! this.isDestroying && Ember_set(this, 'tableApi.topLeftDialog', topLeftDialog));
     this.addComponentClass();
   },
 

--- a/frontend/app/components/panel/genotype-samples.js
+++ b/frontend/app/components/panel/genotype-samples.js
@@ -99,11 +99,13 @@ export default class PanelGenotypeSamplesComponent extends Component {
     passportFields = this.args.userSettings.passportFields,
     selectFields = passportFields.length ? passportFields : undefined,
     passportP = aggSamples.length ?
-      getPassportData({ genotypeIds, selectFields }, genolinkBaseUrl) :
+      Promise.all(
+        getPassportData({ genotypeIds, selectFields }, genolinkBaseUrl))
+      .then(a => [].concat.apply([], a)) :
       Promise.reject('No AGG samples out of ' + g.selectedSamples.length);
     passportP.then(resultByGenotype => {
       console.log("Result by genotype IDs:", resultByGenotype);
-      const data = resultByGenotype.content;
+      const data = resultByGenotype;
       // just to test array.
       data.forEach(row => (row.aliases = row.aliases.mapBy('name')));
       const

--- a/frontend/app/components/panel/genotype-search.js
+++ b/frontend/app/components/panel/genotype-search.js
@@ -112,7 +112,9 @@ export default class PanelGenotypeSearchComponent extends Component {
     this.navigateGenotypeTableP().then(() => {
       // equivalent : manageGenotype.vcfGenotypeSamplesSelectedAll
       const selectedSamples = this.args.userSettings.vcfGenotypeSamplesSelected[this.selectedDatasetId];
-      this.selectedSamplesText = selectedSamples ? selectedSamples.join('\n') : '';
+      if (selectedSamples || this.selectedSamplesText === undefined) {
+        this.selectedSamplesText = selectedSamples ? selectedSamples.join('\n') : '';
+      }
     });
   }
 

--- a/frontend/app/components/panel/manage-genotype.js
+++ b/frontend/app/components/panel/manage-genotype.js
@@ -518,8 +518,12 @@ export default class PanelManageGenotypeComponent extends Component {
     }
 
     //--------------------------------------------------------------------------
-    const selectedSamples = userSettings.vcfGenotypeSamplesSelected[userSettings.selectedDatasetId];
-    later(() => this.selectedSamplesText = selectedSamples ? selectedSamples.join('\n') : '');
+    if (userSettings.selectedDatasetId) {
+      const selectedSamples = userSettings.vcfGenotypeSamplesSelected[userSettings.selectedDatasetId];
+      if (selectedSamples || (this.selectedSamplesText === undefined)) {
+        later(() => this.selectedSamplesText = selectedSamples ? selectedSamples.join('\n') : '');
+      }
+    }
     //--------------------------------------------------------------------------
 
     if (userSettings.samplesIntersection === undefined) {

--- a/frontend/app/components/panel/manage-genotype.js
+++ b/frontend/app/components/panel/manage-genotype.js
@@ -97,6 +97,8 @@ import { Germinate } from '../../utils/data/germinate';
 const dLog = console.debug;
 
 const trace = 0;
+/** Enable trace of comparison / sorting of sample columns, via selected genotypic pattern. */
+const trace_sort = 0;
 
 const featureSymbol = Symbol.for('feature');
 
@@ -3883,7 +3885,9 @@ export default class PanelManageGenotypeComponent extends Component {
        * missing data is not sorted
        */
       ratio = Measure.average(ms, distanceCount);
-      dLog(fnName, sampleName, ratio, distanceCount, blocks.length);
+      if (trace_sort) {
+        dLog(fnName, sampleName, ratio, distanceCount, blocks.length);
+      }
       this.matchesSummary[sampleName] = ratio;
     }
     return ratio;

--- a/frontend/app/components/panel/select-passport-fields.js
+++ b/frontend/app/components/panel/select-passport-fields.js
@@ -69,8 +69,17 @@ export default class PanelSelectPassportFieldsComponent extends Component {
     });
   }
 
+  /** The user has completed changes to the selected .passportFields, so now
+   * update the Genotype Table display.
+   */
   @action
   updateAndClose() {
+    /** If the user clicks before selectedFieldsChanged() ->
+     * datasetsGetPassportData() has resolved, then this re-display will not
+     * show the new passport data. After resolving, datasetsGetPassportData()
+     * also signals passportDataCount which enables selectedSampleEffect() ->
+     * showSamplesWithinBrush() to refresh the display.
+     */
     this.args.genotypeTable.showSamplesWithinBrush();
     const userSettings = this.args.userSettings;
     Ember_set(userSettings, 'showSelectPassportFields', false);

--- a/frontend/app/components/panel/sequence-search.js
+++ b/frontend/app/components/panel/sequence-search.js
@@ -467,7 +467,7 @@ export default Component.extend({
 
   selectResultTab(tabId) {
     this.bsTab.select(tabId);
-    this.set('bsTab.activeId', tabId);
+    this.bsTab.activeId = tabId;
   },
 
   /*--------------------------------------------------------------------------*/

--- a/frontend/app/components/panel/upload/blast-results-view.js
+++ b/frontend/app/components/panel/upload/blast-results-view.js
@@ -431,12 +431,15 @@ export default Component.extend({
   resultParentBlocksByName : computed('parentBlocks', 'blockNames.[]', function () {
     const fnName = 'resultParentBlocksByName';
 
+    if (! this.parentBlocks.length) {
+      return {};
+    }
     let blockNames = this.get('blockNames');
     const
     blocks = this.parentBlocks
       .reduce((result, block) => {result[block.get('name')] = block; return result; }, {});
 
-    if (! blocks.length && blockNames.length) {
+    if (! Object.keys(blocks).length && blockNames.length) {
       const parentName = this.get('search.parent');
       dLog(fnName, parentName, blockNames, blocks);
     }
@@ -503,8 +506,8 @@ export default Component.extend({
       /* from a quick look, blockScopes and scopesForNames are probably similar
        * solutions to the same problem, from different branches, and likely the same.
        * from these branches / commits :
-       *   blockScopes    : [feature/ongoingGenotype ade64e58] Load blast search results with block .scope matching reference
-       *   scopesForNames : [feature/upgradeFrontend 8c8d63c2] update axis drag, feature search results display
+       *   scopesForNames : [feature/ongoingGenotype ade64e58] Load blast search results with block .scope matching reference
+       *   blockScopes    : [feature/upgradeFrontend 8c8d63c2] update axis drag, feature search results display
        */
       if (! isEqual(this.blockScopes, scopesForNames) ||
           (this.blockScopes.length < this.get('blockNames.length')) ||

--- a/frontend/app/components/table-brushed.js
+++ b/frontend/app/components/table-brushed.js
@@ -767,7 +767,7 @@ export default Component.extend({
         minRows: 1,
         rowHeaders: true,
         headerTooltips: true,
-        height: '100%',
+        height: '98%',	// 100% doesn't show horiz scrollbar
         manualRowResize: true,
         manualColumnResize: true,
         manualRowMove: true,

--- a/frontend/app/services/data/block.js
+++ b/frontend/app/services/data/block.js
@@ -691,7 +691,12 @@ export default Service.extend(Evented, {
    */
   peekBlock(blockId)
   {
+    const fnName = 'peekBlock';
     if ((blockId === undefined) || (blockId === null)) {
+      return undefined;
+    }
+    if (typeof blockId != 'string') {
+      dLog(fnName, 'blockId', blockId);
       return undefined;
     }
     let

--- a/frontend/app/services/data/block.js
+++ b/frontend/app/services/data/block.js
@@ -16,6 +16,7 @@ import { stacks } from '../../utils/stacks';
 import { intervalSize, truncateMantissa }  from '../../utils/interval-calcs';
 import { featuresCountsResultSum } from '../../utils/draw/featuresCountsResults';
 import { breakPoint } from '../../utils/breakPoint';
+import { findResult } from '../../utils/common/arrays';
 
 //------------------------------------------------------------------------------
 
@@ -708,7 +709,7 @@ export default Service.extend(Evented, {
     if (store) {
       block = store && store.peekRecord('block', blockId);
     } else {
-      block = Object.values(apiServers.servers).find(
+      block = findResult(Object.values(apiServers.servers),
         apiServer => apiServer.store.peekRecord('block', blockId));
     }
     return block;

--- a/frontend/app/services/data/paths-progressive.js
+++ b/frontend/app/services/data/paths-progressive.js
@@ -749,7 +749,11 @@ export default Service.extend({
     let dataBlockIds =
         all ? [blockA] :
         axis.dataBlocksFiltered(true, false)
-        .filter((block) => block.get('isBrushableFeatures'))
+        /* filter out blocks which are transient (e.g. blast search results or
+         * PanBARLEX), or are not brushable because of zoom / feature density /
+         * threshold */
+        .filter((block) =>
+          ! block.hasTag('transient') && block.get('isBrushableFeatures'))
       .map(function (block) { return block.id; });
     /** The result of passing multiple blockIds to getBlockFeaturesInterval()
      * has an unevenly distributed result : all the results come from just 1 of

--- a/frontend/app/services/data/transient.js
+++ b/frontend/app/services/data/transient.js
@@ -149,6 +149,7 @@ export default Service.extend({
    * viewing of distinct result sets.
    * @param view a flag per-feature to enable display of the feature row;
    * from values of the View checkbox column of the results features table.
+   * @return {Promise<Array<object>>} promise yielding array of stored features
    */
   showFeatures(dataset, blocks, features, active, view) {
     let
@@ -156,6 +157,7 @@ export default Service.extend({
     // may pass dataset, blocks to pushFeature()
     stored = features.map((f) => this.pushFeature(f));
     stored.forEach((feature, i) => this.showFeature(feature, active && view[i]));
+    return stored;
   },
   showFeature(feature, viewFeaturesFlag) {
     let

--- a/frontend/app/styles/app.scss
+++ b/frontend/app/styles/app.scss
@@ -2724,6 +2724,7 @@ div.genotype .ember-tooltip
 
 /* -------------------------------------------------------------------------- */
 
+/** Also defined in bootstrap/scss/utilities/_sizing.scss */
 .h-100 {
   height: 100%;
 }
@@ -2731,6 +2732,14 @@ div.genotype .ember-tooltip
   width: 100%;
 }
 
+/*----------------------------------------------------------------------------*/
+
+.right-panel-height
+{
+  height: 100%;
+}
+
+/*----------------------------------------------------------------------------*/
 
 /* div#table-brushed.handsontable */
 

--- a/frontend/app/templates/components/panel/left-panel.hbs
+++ b/frontend/app/templates/components/panel/left-panel.hbs
@@ -49,6 +49,7 @@
                 primaryDatasets=@model.availableMapsTask._result
                 mapviewDatasets=this.datasets
                 refreshDatasets=this.refreshDatasets
+                viewDataset=this.viewDataset
                 loadBlock=this.loadBlock
                 onDelete=this.onDelete
                 selectBlock=this.selectBlock

--- a/frontend/app/templates/mapview.hbs
+++ b/frontend/app/templates/mapview.hbs
@@ -92,7 +92,7 @@
     <div>
 
   {{#if this.layout.right.visible}}
-    <div id="right-panel" class="h-100">
+    <div id="right-panel" class="right-panel-height">
 
       <ul class="nav nav-tabs">
         {{#if this.model.params.parsedOptions.blockTab}}
@@ -180,7 +180,7 @@
         {{/elem/button-tab}}
       </ul>
 
-      <div id="right-panel-content"  class={{this.rightPanelClass}}>
+      <div id="right-panel-content"  class="d-flex flex-column {{this.rightPanelClass}}">
         {{#if (compare this.layout.right.tab '===' 'selection')}}
           {{panel/manage-features
             selectedFeatures=this.selectedFeatures

--- a/frontend/app/utils/common/arrays.js
+++ b/frontend/app/utils/common/arrays.js
@@ -1,5 +1,20 @@
 //------------------------------------------------------------------------------
 
+/** Wrap Array.find(); return the result of fn(elt) instead of elt.
+ * Usage : instead of array.find(fn), use findResult(array, fn).
+ * @param {Array<any>} array
+ * @param {function} fn
+ * @return {any} undefined if fn(elt) is falsey for all elt of array,
+ * otherwise the first value of fn(elt) which is truthy.
+ */
+export function findResult(array, fn) {
+  let result;
+  array.find((elt, i) => result = fn(elt, i));
+  return result;
+}
+
+//------------------------------------------------------------------------------
+
 export { toggleString };
 
 /** Equivalent to toggleObject() but for String.

--- a/frontend/app/utils/data/genotype-order.js
+++ b/frontend/app/utils/data/genotype-order.js
@@ -15,6 +15,8 @@ import {
 
 const dLog = console.debug;
 
+const trace = 0;
+
 //----------------------------------------------------------------------------
 
 /** The following classes implement a common API, which is referred to as Measure :
@@ -153,7 +155,9 @@ Counts.cmp = function(counts1, counts2) {
     (counts1.differences - counts2.differences) ||
     (counts1.missing - counts2.missing);
 */
-  dLog('cmp', cmp, counts1, counts2);
+  if (trace) {
+    dLog('cmp', cmp, counts1, counts2);
+  }
   return cmp;
 };
 Counts.count = function(sampleMatch, match) {

--- a/frontend/app/utils/data/panBARLEX.js
+++ b/frontend/app/utils/data/panBARLEX.js
@@ -1,0 +1,151 @@
+import { later } from '@ember/runloop';
+
+import { isEqual } from 'lodash/lang';
+// import { nowOrLater } from '../../../utils/ember-devel';
+
+/** Before using these functions, init() is required, and is called by the
+ * calling component (manage-explorer) */
+import {
+  clusterIds, getChromosomes, getGene, geneToFeature
+} from '@plantinformatics/vcf-genotype-brapi';  // ipkPanbarlexServer
+// } from '../../utils/ipk-panbarlex-server'; // devel
+
+//------------------------------------------------------------------------------
+
+const dLog = console.debug;
+
+//------------------------------------------------------------------------------
+
+/** Given the chromosome information from contig_length, create a Dataset and
+ * Blocks, pushed into the store.
+ *
+ * Usage :
+ *   getChromosomes(referenceAssemblyName).then(chrs => pushChromosomes( , chrs)
+ * @param {object} this		object to store .dataset and .blocks
+ * @param {object} transient	service('data/transient'),
+ * @param {Array<object>} chrs	result from getChromosomes()
+ * @return {object} datasetBlocks {dataset, blocks} handles of records pushed
+ * into Ember Data store
+ */
+export function pushChromosomes(transient, chrs) {
+  let result;
+
+  const
+  referenceAssemblyName = chrs[0].sampleId; // 'Morex',
+  {
+    const
+    blockNames = chrs.mapBy('contigId'),
+    scopesForNames = blockNames,
+    features = [];
+
+    {
+      const
+      parentName = 'RGT_PlanetV1', // parent displayName : Hordeum vulgare-RGT_PlanetV1-Genome', // 'Barley_MorexV3',
+      namespace = 'Hordeum vulgare-RGT_PlanetV1';
+
+      /** Based on panel/upload/blast-results-view.js : viewFeatures() */
+
+      const
+      /** append parentName to make transient datasets distinct by parent */
+      datasetName = ('PanBARLEX_' + referenceAssemblyName /*+ parentName*/),
+      dataset = transient.pushDatasetArgs(
+        datasetName,
+        parentName,
+        namespace
+      );
+
+      let blocks = transient.blocksForSearch(
+        datasetName,
+        blockNames,
+        scopesForNames,
+        namespace
+      );
+      transient.datasetBlocksResolveProxies(dataset, blocks);
+
+      /** Copy [start, end] from chrs[] to blocks[].range */
+      blocks.forEach((b,i) =>
+        b.range ||
+          ((b.name == chrs[i].contigId) &&
+           b.set('range', [1, chrs[i].length])));
+
+      result = {dataset, blocks};
+    }
+  }
+  return result;
+}
+/** For the given Feature data, if its parent block is viewed, load into the
+ * Ember Data store, and show it.
+ * Currently called with 1 feature at a time, to provide a smooth / progressive
+ * display update in the GUI, and smooth the load on the server.
+ * @param {object} this		object in which pushChromosomes() has stored
+ * .dataset and .blocks
+ * @param {object} transient	service('data/transient'),
+ * @param {Array<object>} features	result from getGene() or  getGKnownGenes()
+ * @return {object} stored Feature object, if features?.length, otherwise undefined.
+ */
+export function pushFeatures(transient, datasetBlocks, features) {
+  const
+  dataset = datasetBlocks.dataset,
+  datasetName = dataset.id,
+  blocks = datasetBlocks.blocks;
+
+  if (features && features.length) {
+
+    /** change features[].blockId to match blocks[], which has dataset.id prefixed to make them distinct.  */
+    let featuresU = features.map((f) => { let {blockId, ...rest} = f; rest.blockId = dataset.id + '-' + blockId; return rest; });
+
+    const featuresInView = featuresU.filter(f => blocks.findBy('id', f.blockId)?.isViewed);
+    /** Param viewRow[] needs to cover featuresU[], which atm has length 0 or 1,   */
+    const stored = transient.showFeatures(dataset, blocks, featuresInView, /*active*/true, /*viewRow*/[true]);
+
+    return stored;
+  }
+}
+
+/** draft for adding a single feature.  May not be required.
+ * @param featureData similar to features[row]
+ */
+function addFeature(transient, featureData, row) {
+  const
+  feature = transient.pushFeature(featureData);
+  later(
+    () => transient.showFeature(feature, viewFeaturesFlag));
+}
+
+//------------------------------------------------------------------------------
+
+/** Get PanBARLEX Known Genes data, create a dataset and blocks (chromosomes)
+ * and insert the feature data in the blocks.  View the blocks and the features.
+ * @param {object} transient	service('data/transient')
+ */
+export function knownGenesDataset(transient, viewDataset) {
+  const fnName = 'knownGenesDataset';
+  getChromosomes('Morex').then(responses => {
+    dLog('getChromosomes', responses);
+    const datasetBlocks = pushChromosomes(transient, responses);
+
+    const
+    dataset = datasetBlocks.dataset,
+    datasetName = dataset.id,
+    blocks = datasetBlocks.blocks;
+    viewDataset(datasetName, blocks);
+    // pushFeatures() will showFeatures() for blocks which are viewed.
+    later(() => showGenes());
+
+    function showGenes() {
+    const
+    allP = Promise.all(clusterIds.map(clusterId =>
+      getGene(clusterId).then(gene => {
+        const feature = geneToFeature(gene);
+        const f = pushFeatures(transient, datasetBlocks, [feature]);
+        return f;
+      })));
+    allP.then(features => dLog(fnName, features.length));
+    }
+
+  });
+}
+
+
+//------------------------------------------------------------------------------
+

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pretzel-frontend",
-  "version": "3.9.1",
+  "version": "3.9.2",
   "description": "Frontend code for Pretzel",
   "repository": "",
   "license": "MIT",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -105,7 +105,7 @@
   },
   "dependencies": {
     "@ember/test-helpers": "^3.3.0",
-    "@plantinformatics/vcf-genotype-brapi": "^1.0.25",
+    "@plantinformatics/vcf-genotype-brapi": "^1.0.26",
     "@solgenomics/brapijs": "https://github.com/solgenomics/BrAPI-js.git",
     "@voll/ember-parachute": "^2.0.0",
     "bluebird": "^3.7.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -105,7 +105,7 @@
   },
   "dependencies": {
     "@ember/test-helpers": "^3.3.0",
-    "@plantinformatics/vcf-genotype-brapi": "^1.0.24",
+    "@plantinformatics/vcf-genotype-brapi": "^1.0.25",
     "@solgenomics/brapijs": "https://github.com/solgenomics/BrAPI-js.git",
     "@voll/ember-parachute": "^2.0.0",
     "bluebird": "^3.7.2",

--- a/lb4app/lb3app/common/models/block.js
+++ b/lb4app/lb3app/common/models/block.js
@@ -21,6 +21,8 @@ const { getAliases } = require('../utilities/localise-aliases');
 const { childProcess, dataOutReplyClosure, dataOutReplyClosureLimit } = require('../utilities/child-process');
 const { ArgsDebounce } = require('../utilities/debounce-args');
 const { ErrorStatus } = require('../utilities/errorStatus.js');
+const { arrayFieldToHex } = require('../utilities/mongoDB-driver-lib.js');
+
 
 let vcfGenotypeSamplesFiltered, vcfGenotypeHaplotypesSamples, vcfGenotypeLookup, vcfGenotypeFeaturesCounts;
 import('@plantinformatics/vcf-genotype-brapi/dist/vcf-genotype-brapi-node.mjs').then(vcfGenotypeBrapi => {
@@ -773,6 +775,12 @@ function blockAddFeatures(db, datasetId, blockId, features, cb) {
     cacheId = fnName + '_' + blockIds.join('_'),
     result = cache.get(cacheId);
     if (result) {
+      if (result[0]?._id._bsontype) {
+        console.log(fnName, result[0]);
+        result = arrayFieldToHex(result, '_id');
+        console.log(fnName, result[0], 'arrayFieldToHex');
+        cache.put(cacheId, result);
+      }
       if (trace_block > 1) {
         console.log(fnName, cacheId, 'get', result[0] || result);
       }
@@ -786,6 +794,7 @@ function blockAddFeatures(db, datasetId, blockId, features, cb) {
       if (trace_block > 1) {
         console.log(fnName, cacheId, 'get', featureCounts[0] || featureCounts);
       }
+      featureCounts = arrayFieldToHex(featureCounts, '_id');
       cache.put(cacheId, featureCounts);
       cb(null, featureCounts);
     }).catch(function(err) {
@@ -1077,6 +1086,12 @@ function blockAddFeatures(db, datasetId, blockId, features, cb) {
       if (trace_block > 1) {
         console.log(apiName, cacheId, 'get', cached.length || cached);
       }
+      if (cached[0]?._id._bsontype) {
+        console.log(apiName, cached[0]);
+        cached = arrayFieldToHex(cached, '_id');
+        console.log(apiName, cached[0], 'arrayFieldToHex');
+        cache.put(cacheId, cached);
+      }
       let filteredData = pathsFilter.filterFeatures(cached, intervals);
       cb(null, filteredData);
     }
@@ -1086,6 +1101,7 @@ function blockAddFeatures(db, datasetId, blockId, features, cb) {
       cursor.toArray()
         .then(function(data) {
           console.log(apiName, ' then', (data.length > 2) ? data.length : data);
+          data = arrayFieldToHex(data, '_id');
           if (useCache) {
             cache.put(cacheId, data);
             if (trace_block > 1) {

--- a/lb4app/lb3app/common/models/block.js
+++ b/lb4app/lb3app/common/models/block.js
@@ -970,6 +970,11 @@ function blockAddFeatures(db, datasetId, blockId, features, cb) {
       if (trace_block > 1) {
         console.log(fnName, cacheId, 'put', limits[0] || limits);
       }
+      /** _id was received as ObjectID; this seems to be a change, possibly
+       * caused by upgrading Node.js in build from 16 to 22.
+       * Map the ObjectID-s to hex strings, which is the form the client is expecting.
+       */
+      limits = limits.map(({_id, ...rest}) => ({_id : _id.toHexString(), ...rest}));
       cache.put(cacheId, limits);
       cb(null, limits);
     }).catch(function(err) {

--- a/lb4app/lb3app/common/utilities/mongoDB-driver-lib.js
+++ b/lb4app/lb3app/common/utilities/mongoDB-driver-lib.js
@@ -4,8 +4,10 @@ const { ErrorStatus } = require('./errorStatus.js');
 
 /* global require */
 /* global exports */
+/* global Buffer */
 
-var ObjectId = require('mongodb').ObjectID;
+const { ObjectID } = require('mongodb');
+
 
 /** @return true if id1 and id2 represent the same mongoDB ObjectId
  * @param id1, id2	String or ObjectId
@@ -43,5 +45,58 @@ exports.objectLookup = function(model, modelName, fnName, objectId, options) {
   return objectP;
 };
 
+
+//------------------------------------------------------------------------------
+
+/** Rehydrate a MongoDb ObjectID which has been stored in cache and read back,
+ * and hence has lost its prototype.
+ * @param {object} obj
+ * e.g. {"_bsontype":"ObjectID","id":{"0":97,"1":3,"2":221,"3":216,"4":121,"5":100,"6":79,"7":16,"8":229,"9":189,"10":66,"11":236}}
+ */
+let hexToObjectID = function (obj) {
+  const objectID = new ObjectID(Buffer.from(Object.values(obj.id)));
+  return objectID;
+};
+function x(objectID) {
+  // Convert to hex string
+  const hexString = objectID.toHexString();
+  return hexString;
+};
+// hexToId(temp1)
+
+
+/** If i has .toHexString, call it to transform it to the equivalent hex string.
+ * Otherwise if it has ._bsontype and .id, convert to a MongoDb ObjectID object, then use .toHexString().
+ * Otherwise no change.
+ * @param {string|object} i either a (hex) string, or a MongoDb ObjectID object.
+ * @return hex string representing an MongoDb ObjectID.
+ */
+let idToHex = function(i) {
+  const
+  hex = i.toHexString ? i.toHexString() :
+    (i._bsontype && i.id) ? hexToObjectID(i).toHexString() :
+    i ;
+  return hex;
+};
+/** In the given array of objects, convert id fields, identified by fieldName,
+ * to hex string representation.
+ * id values in cached results should be in hex string representation.
+ * This function is used to fix cached results, and to ensure results have ids
+ * in hex string representation before they are written to cache.
+ * Calling cb(null, result) probably converts objects using .toString(), which
+ * for id fields which are ObjectID will convert them to hex representation. But
+ * reading this value back from cache does not re-hydrate its .__proto__.
+ * So when that result is returned via cb(), it is apparently converted via
+ * JSON.stringify(), i.e. the _bsontype and array of integers is sent instead of
+ * the hex representation.
+ * @param {Array<object>} a result array; each element is an object containing
+ * [fieldname] which is some representation of an ObjectID.
+ * @param {string} fieldName	name of id field, e.g. '_id'
+ */
+exports.arrayFieldToHex =  function(a, fieldName) {
+  return a.map(({[fieldName] : i, ... e}) => ({ [fieldName] : idToHex(i), ... e}));
+};
+// arrayFieldToHex(data, '_id')
+// arrayFieldToHex(cached, '_id')
 
 //------------------------------------------------------------------------------

--- a/lb4app/package.json
+++ b/lb4app/package.json
@@ -61,7 +61,7 @@
     "@loopback/rest-explorer": "^4.1.0",
     "@loopback/service-proxy": "^4.1.0",
     "@plantinformatics/child-process-progressive": "github:plantinformatics/child-process-progressive",
-    "@plantinformatics/vcf-genotype-brapi": "^1.0.25",
+    "@plantinformatics/vcf-genotype-brapi": "^1.0.26",
     "@solgenomics/brapijs": "github:solgenomics/BrAPI-js",
     "async": "^3.2.3",
     "bent": "^7.3.12",

--- a/lb4app/package.json
+++ b/lb4app/package.json
@@ -61,7 +61,7 @@
     "@loopback/rest-explorer": "^4.1.0",
     "@loopback/service-proxy": "^4.1.0",
     "@plantinformatics/child-process-progressive": "github:plantinformatics/child-process-progressive",
-    "@plantinformatics/vcf-genotype-brapi": "^1.0.24",
+    "@plantinformatics/vcf-genotype-brapi": "^1.0.25",
     "@solgenomics/brapijs": "github:solgenomics/BrAPI-js",
     "async": "^3.2.3",
     "bent": "^7.3.12",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pretzel",
   "private": true,
-  "version": "3.9.1",
+  "version": "3.9.2",
   "dependencies": {
   },
   "repository" :


### PR DESCRIPTION
#### Changes Implemented in this release

- change ObjectIDs in API responses : blockFeatureLimits, blockFeaturesCount and blockFeaturesInterval
 f75829d0 convert _id ObjectID-s to hex strings in blockFeatureLimits response
 13150c5d ensure hex string is sent in API response instead of ObjectID for blockFeaturesCount and blockFeaturesInterval

- ensure space for the horizontal scroll bar in features table and genotype table
 4bf36ab4 adjust heights of the features table and genotype table so that there is vertical space at the bottom of the window to display the horizontal scroll bar

 089fe71f Don't clear selectedSamplesText when selectedDatasetId is undefined.

 7a50a9ef refresh Genotype Table display when passport data is received after user closes passport fields selection

- enable passport data to be read for large numbers of samples
 521f1654 request passport data in chunks of 100
 bd56186d update update dependency to 1.0.25, for genolink-passport.js : getPassportData() split requests into chunks of 100

 6758e9f0 display PanBARLEX Known Genes as transient features
 fe6b06b5 update version to 3.9.2
