### PR TITLE
Release v3.11.2 :  - Clear selectedSamples when user changes dataset

### DIFF
--- a/frontend/app/components/panel/genotype-samples.hbs
+++ b/frontend/app/components/panel/genotype-samples.hbs
@@ -22,9 +22,10 @@
   <div>
    
     <span>
+    {{!-- disabled if no SNPs selected, but enabled if true, so user can clear it. --}}
     <input type="checkbox"
       checked={{@userSettings.filterSamplesByHaplotype}}
-      disabled={{not @the.featureFiltersCountOfDatasetInBrushedDomain.length}}
+      disabled={{and (not @the.featureFiltersCountOfDatasetInBrushedDomain.length) (not @userSettings.filterSamplesByHaplotype)}}
       oninput={{pipe (action (mut @userSettings.filterSamplesByHaplotype) value="target.checked")
         @the.ensureSamples }}  >
     <label class={{if (not @the.featureFiltersCountOfDatasetInBrushedDomain.length) "disabled"}}>

--- a/frontend/app/components/panel/genotype-search.js
+++ b/frontend/app/components/panel/genotype-search.js
@@ -194,6 +194,10 @@ export default class PanelGenotypeSearchComponent extends Component {
      * specifically : brushedVCFBlocks evaluates
      * block.genotypeSamplesFilteredByHaplotypes() ->
      * vcfGenotypeSamplesDataset().
+     *
+     * Also : if ! vcfBlock.genotypeSamplesFilteredByHaplotypes.length then
+     * filterSamplesByHaplotype is disregarded, so that case could also return
+     * here.
      */
     if (filterSamplesByHaplotype) {
       return;
@@ -202,6 +206,8 @@ export default class PanelGenotypeSearchComponent extends Component {
       /** A block of .selectedDataset, choosing either the first viewed block or
        * the first block. */
       vcfBlock = this.selectedDataset.get('aBlock');
+    } else if ((vcfBlock = manageGenotype?.lookupBlock)) {
+      datasetId = vcfBlock.get('datasetId.id');
     }
     /** If filterSamplesByHaplotype, the result sampleNames also depends on the
      * filtering haplotypes (i.e. SNPs + genotype values) :

--- a/frontend/app/components/panel/manage-genotype.js
+++ b/frontend/app/components/panel/manage-genotype.js
@@ -1815,8 +1815,21 @@ export default class PanelManageGenotypeComponent extends Component {
    */
   @computed('lookupBlock', 'args.userSettings.selectedDatasetId')
   get lookupDatasetId() {
-    const b = this.lookupBlock;
-    const datasetId = this.args.userSettings.selectedDatasetId || b?.get('datasetId.id');
+    const
+    fnName = 'lookupDatasetId',
+    b = this.lookupBlock,
+    selectedDatasetId = this.args.userSettings.selectedDatasetId,
+    selectedDatasetIdIsCurrent =
+      this.brushedOrViewedVCFBlocksVisible.find(
+        b => b.datasetId.id == selectedDatasetId);
+    if (! selectedDatasetIdIsCurrent) {
+      dLog(fnName, b?.brushName, selectedDatasetId, 'is no longer viewed');
+      this.args.userSettings.selectedDatasetId = undefined;
+    }
+
+    const
+    datasetId = selectedDatasetIdIsCurrent ?
+      selectedDatasetId : b?.get('datasetId.id');
     return datasetId;
   }
   /** Scope of lookupBlock, which used to identify the (reference) chromosome in
@@ -2714,6 +2727,8 @@ export default class PanelManageGenotypeComponent extends Component {
 
   /** Get samples for dataset for this chromosome / VCF Block, filtered by
    * selected SNPs + genotype values, i.e. haplotypes.
+   * genotypeSamplesFilteredByHaplotypes() is currently only used within
+   * .urlOptions.advanced and .devel-visible
    */
   genotypeSamplesFilteredByHaplotypes(vcfBlock) {
     const
@@ -2768,7 +2783,9 @@ export default class PanelManageGenotypeComponent extends Component {
          matchRef : MatchRef.matchRef2Json[f[Symbol.for('matchRef')]]})),
        matchHet
       },
-    filterDescription = filterByHaplotype ?
+    /** falsey if filterByHaplotype?.features is undefined or empty */
+    filterByHaplotypeN = filterByHaplotype?.features.length,
+    filterDescription = filterByHaplotypeN ?
       this.selectedSNPsToKey(filterByHaplotype.features, matchHet) : '',
     requestDescription = "Fetching accessions for " + vcfBlock.brushName + ' ' + filterDescription;
     if (filterByHaplotype) {
@@ -2787,7 +2804,8 @@ export default class PanelManageGenotypeComponent extends Component {
       this.lookupMessage = null;
 
       textP = this.auth.genotypeSamples(
-        vcfBlock, vcfDatasetIdAPI, scope, filterByHaplotype,
+        vcfBlock, vcfDatasetIdAPI, scope,
+        filterByHaplotypeN ? filterByHaplotype : undefined,
         {} );
       textP.then(
         (text) => {
@@ -2834,7 +2852,7 @@ export default class PanelManageGenotypeComponent extends Component {
             dLog(fnName, 'limit sampleNames to', sampleNames.length);
           }
 
-          if (! filterByHaplotype) {
+          if (! filterByHaplotypeN) {
             this.sampleCache.sampleNames[vcfDatasetId] = sampleNamesText;
             this.datasetStoreSampleNames(vcfBlock, sampleNames);
           } else {
@@ -2883,6 +2901,18 @@ export default class PanelManageGenotypeComponent extends Component {
           if ((vcfDatasetId === this.lookupDatasetId) &&
               (this.vcfGenotypeSamplesSelected === undefined)) {
             this.vcfGenotypeSamplesSelected = [];
+            /** Having initialised .selectedSamples, it makes sense to clear
+             * .selectedSamplesText.
+             * For example, when a new dataset is displayed, the previous
+             * .selectedSamplesText should be cleared (we could re-instate the previous selection for
+             * that dataset, as is done when switching between dataset tabs).
+             * .selectedSamples changes are driven by user selections & edits to
+             * .selectedSamplesText.  These 2 are not connected by a computed /
+             * dependency;
+             */
+            if (this.selectedSamplesText) {
+              this.selectedSamplesText = '';
+            }
           }
           this.receivedNamesCount++;
         })
@@ -2994,6 +3024,12 @@ export default class PanelManageGenotypeComponent extends Component {
       dLog(fnName, new Date().toISOString(), this.lookupBlock?.brushName, this.args.userSettings.filterSamplesByHaplotype);
       this.vcfGenotypeSamples();
     }
+
+    // Propagate from previous .selectedSamples of lookupDatasetId, if any.
+    later(() => {
+      const selectedSamples = this.vcfGenotypeSamplesSelectedAll[this.lookupDatasetId];
+      this.selectedSamplesText = selectedSamples ? selectedSamples.join('\n') : '';
+    });
 
   }
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pretzel-frontend",
-  "version": "3.11.1",
+  "version": "3.11.2",
   "description": "Frontend code for Pretzel",
   "repository": "",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pretzel",
   "private": true,
-  "version": "3.11.1",
+  "version": "3.11.2",
   "dependencies": {
   },
   "repository" :


### PR DESCRIPTION
#### Changes Implemented

- clear selectedSamples when user changes dataset
This addresses this reported issue : after user closed a chromosome axis which was viewing a genotype dataset and displayed another genotype dataset, in the genotype table settings dialog the selected samples input field showed the samples selected in the previous dataset.